### PR TITLE
Fix fakts key check

### DIFF
--- a/src/arkitekt/index.tsx
+++ b/src/arkitekt/index.tsx
@@ -100,7 +100,7 @@ export const useArkitektFakts = (key?: undefined | string) => {
       return result;
     }
 
-    if ((fakts as any)[key]) {
+    if (!(key in (fakts as any))) {
       throw new Error(`Missing fakts.${key}`);
     }
     return (fakts as any)[key];


### PR DESCRIPTION
## Summary
- fix `useArkitektFakts` so it only throws when the key is missing

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config)*
- `yarn typecheck` *(fails: missing TS config/deps)*

------
https://chatgpt.com/codex/tasks/task_e_6859678091c08324b067a31ac4041a78