### PR TITLE
fix: handle orkestrator urls and pin action input

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -17,18 +17,24 @@ app.commandLine.appendSwitch("ignore-certificate-errors", "true");
 
 let mainWindow: BrowserWindow | null = null;
 
-ipcMain.handle("download-from-url", async (event, { url }: { url: string }) => {
-  // Check if the URL is valid
-  const win = BrowserWindow.getFocusedWindow();
-  if (!win) return { success: false, error: "No active window" };
+ipcMain.handle(
+  "download-from-url",
+  async (_event, { url }: { url: string }) => {
+    // Check if the URL is valid
+    const win = BrowserWindow.getFocusedWindow();
+    if (!win) return { success: false, error: "No active window" };
 
-  try {
-    const dl = await download(win, url);
-    return { success: true, path: dl.getSavePath() };
-  } catch (err: any) {
-    return { success: false, error: err.message };
-  }
-});
+    try {
+      const dl = await download(win, url);
+      return { success: true, path: dl.getSavePath() };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+);
 
 function handleOrkestratorUrl(url: string) {
   try {
@@ -44,7 +50,7 @@ function handleOrkestratorUrl(url: string) {
 
     openSecondaryWindow(fullPath);
   } catch (err) {
-    console.error("Invalid orkestrator URL", url);
+    console.error("Invalid orkestrator URL", url, err);
     dialog.showErrorBox(
       "Invalid Link",
       `The URL '${url}' could not be processed.`,
@@ -73,7 +79,7 @@ function createWindow(): BrowserWindow {
   });
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    let url = new URL(details.url);
+    const url = new URL(details.url);
 
     console.log(url.hash);
     openSecondaryWindow(url.hash.split("#")[1]);
@@ -192,7 +198,7 @@ function openSecondaryWindow(path: string): void {
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
-    let loaded_url = process.env["ELECTRON_RENDERER_URL"] + "#" + path;
+    const loaded_url = process.env["ELECTRON_RENDERER_URL"] + "#" + path;
     console.log("Loading URL", loaded_url);
     secondaryWindow.loadURL(loaded_url);
   } else {
@@ -260,9 +266,9 @@ if (process.platform == "darwin") {
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
 
-  // Handle the protocol. In this case, we choose to show an Error Box.
-  app.on("open-url", (_, url) => {
-    dialog.showErrorBox("Welcome Back", `You arrived from: ${url}`);
+  // Handle the protocol by forwarding the url to the application logic.
+  app.on("open-url", (_event, url) => {
+    handleOrkestratorUrl(url);
   });
 }
 
@@ -271,17 +277,17 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
-  app.on("second-instance", (_, commandLine) => {
+  app.on("second-instance", (_event, commandLine) => {
     // Someone tried to run a second instance, we should focus our window.
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();
     }
     // the commandLine is array of strings in which last element is deep link url
-    dialog.showErrorBox(
-      "Welcome Back",
-      `You arrived from: ${commandLine.pop()}`,
-    );
+    const url = commandLine.pop();
+    if (url) {
+      handleOrkestratorUrl(url);
+    }
   });
 
   // Create mainWindow, load the rest of the app, etc...

--- a/src/actions/builders/pinAction.tsx
+++ b/src/actions/builders/pinAction.tsx
@@ -16,7 +16,10 @@ export const identifierFromSmartOrString = (identifier: Smart | string) => {
 export type DeleteActionParams = {
   identifier: Smart | string;
   title: string;
-  mutation: TypedDocumentNode<any, { input: {id: string, pin?: boolean | undefined} }>;
+  mutation: TypedDocumentNode<
+    unknown,
+    { input: { id: string; pin?: boolean | undefined } }
+  >;
   service: string;
   description?: string;
 };
@@ -31,19 +34,19 @@ export const buildDeleteAction = (params: DeleteActionParams): Action => ({
       identifier: identifierFromSmartOrString(params.identifier),
     },
   ],
-  execute: async ({ services, onProgress, abortSignal, state }) => {
-    let service = services[params.service]
+  execute: async ({ services, onProgress, state }) => {
+    const service = services[params.service]
       .client as ApolloClient<NormalizedCache>;
     if (!service) {
       throw new Error("Service not found");
     }
 
-    for (let i in state.left) {
+    for (const i in state.left) {
       await service.mutate({
         mutation: params.mutation,
         variables: {
           input: {
-            state.left[i].object,
+            id: state.left[i].object,
             pin: false,
           },
         },


### PR DESCRIPTION
## Summary
- wire up orkestrator protocol handling on macOS and second app instances
- validate pin action input construction

## Testing
- `npx eslint electron/main/index.ts src/actions/builders/pinAction.tsx`
- `npm run typecheck` *(fails: Property 'groups' does not exist on type 'PortFragment', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688de54e2604832498cb2a9106c12200