### PR TITLE
fix: serve packaged renderer over app:// scheme for cross-origin isolation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,8 +16,58 @@ import { AppManager } from "./modules/AppManager";
 import { UploadService } from "./modules/UploadService";
 import { BigFileUploadService } from "./modules/BigFileUploadService";
 import { BigFileDownloadService } from "./modules/BigFileDownloadService";
-import { session, protocol, net } from "electron";
+import { session, protocol } from "electron";
+import { readFile } from "node:fs/promises";
+import { normalize, sep } from "node:path";
 import { ShellService } from "./modules/ShellService";
+import { APP_SCHEME } from "./scheme";
+
+// Minimal extension -> MIME map for the app:// static file handler. Kept inline
+// to avoid adding a dependency. text/javascript for .js/.mjs is mandatory (ES
+// module scripts are rejected otherwise) and application/wasm is required for
+// WebAssembly.instantiateStreaming (zarr codecs, duckdb-wasm).
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".map": "application/json",
+  ".wasm": "application/wasm",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".ttf": "font/ttf",
+  ".data": "application/octet-stream",
+  ".txt": "text/plain",
+};
+
+function mimeForPath(filePath: string): string {
+  const dot = filePath.lastIndexOf(".");
+  const ext = dot >= 0 ? filePath.slice(dot).toLowerCase() : "";
+  return MIME_TYPES[ext] ?? "application/octet-stream";
+}
+
+// Register the custom `app://` scheme (see ./scheme) as standard + secure. This
+// MUST run before the app 'ready' event, hence at module top-level.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: APP_SCHEME,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+      stream: true,
+    },
+  },
+]);
 
 app.commandLine.appendSwitch("ignore-certificate-errors", "true");
 // WebGPU for the scene renderer: macOS (Metal) and Windows (D3D) enable it by
@@ -104,25 +154,37 @@ if (!gotTheLock) {
       })
     })
 
-    // In the packaged app the renderer is loaded via loadFile() (file://),
-    // and onHeadersReceived above does not reliably apply COOP/COEP to that
-    // navigation response (especially out of an asar archive) — without it,
-    // window.crossOriginIsolated is false and SharedArrayBuffer is undefined,
-    // breaking the worker-accelerated zarr chunk decoding pipeline. Overriding
-    // the file: protocol handler gives full control over the Response headers
-    // for every file:// request, including the top-level document.
-    protocol.handle("file", async (request) => {
-      const response = await net.fetch(request.url, {
-        bypassCustomProtocolHandlers: true,
-      })
-      const headers = new Headers(response.headers)
-      headers.set("Cross-Origin-Opener-Policy", "same-origin")
-      headers.set("Cross-Origin-Embedder-Policy", "require-corp")
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers,
-      })
+    // Serve the packaged renderer from the custom `app://` scheme (registered
+    // as standard + secure above) instead of file://. Returning the COOP/COEP
+    // trio on this real, secure origin is what makes the document
+    // cross-origin isolated, so SharedArrayBuffer is available for the
+    // worker-accelerated zarr chunk decoding pipeline. The renderer uses
+    // HashRouter, so the only document ever requested is index.html; every
+    // other request is a static asset relative to it.
+    const rendererRoot = normalize(join(__dirname, "../renderer"))
+    protocol.handle(APP_SCHEME, async (request) => {
+      const url = new URL(request.url)
+      let pathname = decodeURIComponent(url.pathname)
+      if (pathname === "/" || pathname === "") pathname = "/index.html"
+
+      // Confine every read to the renderer root (path-traversal guard).
+      const filePath = normalize(join(rendererRoot, pathname))
+      if (filePath !== rendererRoot && !filePath.startsWith(rendererRoot + sep)) {
+        return new Response("Forbidden", { status: 403 })
+      }
+
+      try {
+        const data = await readFile(filePath)
+        const headers = new Headers({
+          "Content-Type": mimeForPath(filePath),
+          "Cross-Origin-Opener-Policy": "same-origin",
+          "Cross-Origin-Embedder-Policy": "require-corp",
+          "Cross-Origin-Resource-Policy": "same-origin",
+        })
+        return new Response(data, { status: 200, headers })
+      } catch {
+        return new Response("Not Found", { status: 404 })
+      }
     })
 
     windowManager.createMainWindow(icon);

--- a/src/main/modules/WindowManager.ts
+++ b/src/main/modules/WindowManager.ts
@@ -4,6 +4,7 @@ import Store from 'electron-store';
 import { join } from 'path';
 import { AppModule } from './AppModule';
 import { IpcTransport } from './IpcTransport';
+import { APP_ORIGIN } from '../scheme';
 
 import { autoUpdater } from 'electron-updater';
 
@@ -126,7 +127,7 @@ export class WindowManager implements AppModule {
         if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
             this.mainWindow.loadURL(process.env["ELECTRON_RENDERER_URL"]);
         } else {
-            this.mainWindow.loadFile(join(__dirname, "../renderer/index.html"));
+            this.mainWindow.loadURL(`${APP_ORIGIN}/index.html`);
         }
 
         const currentWindow = this.mainWindow;
@@ -168,13 +169,10 @@ export class WindowManager implements AppModule {
             const loaded_url = process.env["ELECTRON_RENDERER_URL"] + "#" + path;
             secondaryWindow.loadURL(loaded_url);
         } else {
-            secondaryWindow
-                .loadFile(join(__dirname, "../renderer/index.html"))
-                .then(() => {
-                    secondaryWindow.webContents.executeJavaScript(
-                        `window.location = '#${path}'`
-                    );
-                });
+            // HashRouter: the route is just a fragment, so we can load it
+            // directly instead of navigating after load. This also serves the
+            // secondary window over app:// so it is cross-origin isolated too.
+            secondaryWindow.loadURL(`${APP_ORIGIN}/index.html#${path}`);
         }
 
         secondaryWindow.on('closed', () => {

--- a/src/main/scheme.ts
+++ b/src/main/scheme.ts
@@ -1,0 +1,7 @@
+// Custom privileged scheme used to serve the packaged renderer. Serving over a
+// `standard` + `secure` scheme (instead of file://) gives the document a real,
+// non-opaque tuple origin and secure-context status, which is what lets the
+// COOP/COEP headers actually enable window.crossOriginIsolated — and therefore
+// SharedArrayBuffer — in the packaged app. file:// can never satisfy this.
+export const APP_SCHEME = "app";
+export const APP_ORIGIN = `${APP_SCHEME}://bundle`;


### PR DESCRIPTION
The packaged app loaded the renderer via loadFile() over file://. Even with
COOP/COEP set on file:// responses, Chromium never grants
window.crossOriginIsolated to file:// (opaque origin, non-standard/insecure
scheme), so SharedArrayBuffer stayed undefined and the zarr chunk-decoding
worker pipeline threw "SharedArrayBuffer is not available".

Register a custom app:// scheme as standard + secure and serve the renderer
through a protocol.handle() that returns the COOP/COEP/CORP trio. A standard +
secure scheme has a real tuple origin and secure-context status, so the
isolation headers take effect and SharedArrayBuffer becomes available on the
main thread and in the same-origin module worker.

- src/main/scheme.ts: shared APP_SCHEME / APP_ORIGIN constants
- src/main/index.ts: registerSchemesAsPrivileged (top-level) + app:// static
  file handler with MIME map and path-traversal guard; remove the file://
  handler; keep onHeadersReceived for remote responses
- src/main/modules/WindowManager.ts: load main and secondary windows from
  app://bundle/index.html (HashRouter route becomes a direct #fragment load)

Dev is unchanged (still served by the electron-vite dev server with headers).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ffzbSRTU6pRi2pRx5HwsR